### PR TITLE
Make Feature Request template more concise

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,36 +8,27 @@ assignees: ''
 ---
 
 <!--
-By filing an Issue, you are expected to comply with the elementary code of conduct: https://elementary.io/code-of-conduct
-
-Please note that this tracker is only for bugs and feature requests. Please try these locations if you have a question or comment:
-
-  https://elementaryos.stackexchange.com/
-  https://www.reddit.com/r/elementaryos/
-
-Please read and follow these tips:
-https://elementary.io/docs/code/reference#proposing-design-changes
-
-Lastly, be sure to preview your issue before saving. Thanks!
+* Please read and follow these tips: https://elementary.io/docs/code/reference#proposing-design-changes
+* Be sure to search open and closed issues for duplicates
 -->
 
-## Prerequisites
-- [ ] I have searched open and closed issues for duplicates.
 
-## Feature
-**Is your feature request related to a problem? Please describe.**
-<!--A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]-->
+## Problem
+<!--Describe the problem that this new feature or idea is meant to address-->
 
-<!--If applicable, add screenshots or screen recordings to help explain your problem.-->
 
-**Describe the solution you'd like**
-<!--A clear and concise description of what you want to happen. If possible, visualize.-->
 
-**Existing work**
-<!--Does this feature exist elsewhere? Please share as much info as possible about that approach.-->
+## Proposal
+<!--Describe the new feature or idea that you would like to propose-->
 
-**Describe alternatives you've considered**
-<!--A clear and concise description of any alternative solutions or features you've considered.-->
 
-**Additional context**
-<!--Add any other context or screenshots about the feature request here.-->
+
+## Prior Art
+<!--List any supporting examples of how others have implemented this feature-->
+
+
+
+<!--
+* You are expected to comply with the elementary code of conduct: https://elementary.io/code-of-conduct
+* Please be sure to preview your issue before saving. Thanks!
+-->


### PR DESCRIPTION
These templates are so verbose that I just end up deleting them (and it seems like a lot of others do as well)

* Moved the code of conduct line to the bottom 
* Moved the reminder to preview to the bottom since we expect people to do that last
* Removed the checkmark for searching since if you've never used markdown before these symbols mean nothing to you and people usually just leave it unchecked. This is now part of the comment at the top
* Changed the heading "Feature" to "Problem" since that's actually what we want to be described here.
* Changed the bold text "Describeblah blah blah" to "Proposal" since that's what this is
* Changed the bold text "existing work" to "Prior Art" to be more clear what this means. This isn't for like a pull request or a prototype
* Remove alternatives and context because no one has ever actually filled this out and wrote any alternative solutions and I have no idea what "Additional context" even means

Goes with #6 