### PR TITLE
Remove CoC from feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -28,7 +28,4 @@ assignees: ''
 
 
 
-<!--
-* You are expected to comply with the elementary code of conduct: https://elementary.io/code-of-conduct
-* Please be sure to preview your issue before saving. Thanks!
--->
+<!--Please be sure to preview your issue before saving. Thanks!-->


### PR DESCRIPTION
So now that I think about it, GitHub already has CoC stuff built in and the first time you report an issue it prompts you to check it out already. So this is probably not necessary