### PR TITLE
Bug Report: ask not to put things in brackets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,7 @@ body:
       value: |
           * Please read these [Tips](https://docs.elementary.io/contributor-guide/feedback/reporting-issues)
           * Be sure to search open and closed issues for duplicates
+          * Do not put [things in brackets] in your report title
 
   - type: textarea
     attributes:


### PR DESCRIPTION
We sometimes get folks putting things in brackets that are not helpful and/or duplicate information we already ask for in forms. Add a line to remind them not to do that