### PR TITLE
Templates: set issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Issue Report
 description: Report an unexpected behavior or failure (AKA a bug)
+type: "Bug"
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest a new idea or request a missing feature
-labels: [Priority: Wishlist, Needs Design]
+labels: ["Priority: Wishlist", "Needs Design"]
+type: "Feature"
 
 body:
   - type: markdown


### PR DESCRIPTION
Looks like we can automatically set issue types in forms: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms