### PR TITLE
bug_report: Add OS Architecture

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,7 +53,8 @@ body:
       description: The architecture of elementary OS you are using
       options:
         - amd64 (on most hardwares)
-        - arm64 (Raspberry Pi, Apple Silicon, etc.)
+        - arm64 (on Raspberry Pi, Apple Silicon, etc.)
+        - amd64 and arm64 (I have tested on both)
         - Other Architecture (unofficial, community-supported)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,6 +49,17 @@ body:
 
   - type: dropdown
     attributes:
+      label: OS Architecture
+      description: The architecture of elementary OS you are using
+      options:
+        - amd64 (on most hardwares)
+        - arm64 (Raspberry Pi, Apple Silicon, etc.)
+        - Other Architecture (unofficial, community-supported)
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
       label: Session Type
       options:
         - Classic Session (X11, This is the default)


### PR DESCRIPTION
Because we now build arm64 Daily images and there should be issues only affected to arm64.
