### PR TITLE
Bug Report: Add Early Access as a selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,6 +42,7 @@ body:
       options:
         - 8.x (Circe)
         - 7.x (Horus)
+        - Early Access
         - Other Linux
     validations:
       required: true
@@ -76,7 +77,7 @@ body:
       description: The version of the software you are using
       options:
         - Latest release (I have run all updates)
-        - Compiled from git
+        - Early Access or Compiled from git
         - Older release (I have not run all updates)
     validations:
       required: true


### PR DESCRIPTION
I always manually edit to explicit that I'm not on Stable but on Early Access after creating an issue using this template.